### PR TITLE
Use simplejson library instead of json

### DIFF
--- a/anillo/middlewares/json.py
+++ b/anillo/middlewares/json.py
@@ -1,4 +1,7 @@
-import json
+try:
+    import simplejson as json
+except ImportError:
+    import json
 import functools
 from cgi import parse_header
 


### PR DESCRIPTION
We need to serialize a Decimal object in the json object. 

For this reason, only changing simplejson library instead of json, we can do it.